### PR TITLE
Fix search for user/token with try/catch

### DIFF
--- a/src/context/AuthProvider/index.tsx
+++ b/src/context/AuthProvider/index.tsx
@@ -9,12 +9,16 @@ export const AuthProvider = ({ children }: IAuthProvider) => {
   const [auth, setAuth] = useState<IAuth | null>();
 
   useEffect(() => {
-    const user = getLocalStorage('user');
-    const token = getLocalStorage('token');
+    try {
+      const user = getLocalStorage('user');
+      const token = getLocalStorage('token');
 
-    if (user && token) {
-      setAuth({ user, token, authorized: true });
-      Api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+      if (user && token) {
+        setAuth({ user, token, authorized: true });
+        Api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+      }
+    } catch (e) {
+      localStorage.clear();
     }
   }, []);
 


### PR DESCRIPTION
The error occurred when the authprovider tried to parse the information it found but couldn't, now with catch it will clear the data to receive what the application is really expecting